### PR TITLE
chore: update workflows after renaming master -> main

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,7 @@ name: Tests (8.x)
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/transpile.yaml
+++ b/.github/workflows/transpile.yaml
@@ -2,7 +2,7 @@ name: Transpile to 7.x
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 jobs:
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
         with:
-          ref: master
+          ref: main
       - name: Install Dependencies
         run: composer install
       - name: Transpile to 7.3
@@ -46,7 +46,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
         with:
-          ref: master
+          ref: main
       - name: Install Dependencies
         run: composer install
       - name: Transpile to 7.4


### PR DESCRIPTION
This PR updates the files in the workflows directory to change from master to main.

In `transpile.yaml`, I also updated the `ref`s for `actions/checkout@v2` after quickly consulting the docs. However, I haven't used this action before, so if that's a mistake, please let me know and I'll change it.