### PR TITLE
Feat: Add event dispatcher from upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,26 @@ class MyListener implements EventSubscriberInterface
 }
 ```
 
+## Events
+
+There are two kinds of events, events from the base Unleash php sdk and from this Symfony bundle.
+
+### Base SDK events
+
+- `\Unleash\Client\Event\UnleashEvents::FEATURE_TOGGLE_NOT_FOUND`
+- `\Unleash\Client\Event\UnleashEvents::FEATURE_TOGGLE_DISABLED`
+- `\Unleash\Client\Event\UnleashEvents::FEATURE_TOGGLE_MISSING_STRATEGY_HANDLER`
+
+> For more information read the [documentation](https://github.com/Unleash/unleash-client-php/blob/main/doc/events.md) 
+> in the base SDK.
+
+### Symfony bundle events
+
+- `\Unleash\Client\Bundle\Event\UnleashEvents::CONTEXT_VALUE_NOT_FOUND`
+- `\Unleash\Client\Bundle\Event\UnleashEvents::BEFORE_EXCEPTION_THROWN_FOR_ATTRIBUTE`
+
+> The events are documented in relevant parts of this README.
+
 ## Twig
 
 If you use twig you can make use of functions, filters, test and a custom tag. The names are generic, that's why you can

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "symfony/http-client": "^5.0 | ^6.0",
         "symfony/cache": "^5.0 | ^6.0",
         "nyholm/psr7": "^1.0",
-        "unleash/client": "^1.3",
+        "unleash/client": "^1.5",
         "php": "^8.0"
     },
     "autoload": {

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -95,6 +95,7 @@ services:
       - null
       - '@?unleash.client.internal.bootstrap_service'
       - '%unleash.client.internal.fetching_enabled%'
+      - '@?event_dispatcher'
 
   unleash.client.repository:
     class: Unleash\Client\Repository\DefaultUnleashRepository


### PR DESCRIPTION
# Description

The PHP SDK introduced support for event dispatcher, this PR sets the global app event dispatcher as the one used in Unleash.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
