### PR TITLE
fix: cache service

### DIFF
--- a/src/DependencyInjection/Compiler/CacheServiceResolverCompilerPass.php
+++ b/src/DependencyInjection/Compiler/CacheServiceResolverCompilerPass.php
@@ -19,6 +19,9 @@ final class CacheServiceResolverCompilerPass implements CompilerPassInterface
         assert(is_array($configs));
 
         $cacheServiceName = $configs['cache_service'];
+        if ($container->hasAlias($cacheServiceName)) {
+            $cacheServiceName = $container->getAlias($cacheServiceName);
+        }
         $definition = $container->getDefinition($cacheServiceName);
         $class = $definition->getClass();
         assert(is_string($class));


### PR DESCRIPTION
# Description

Allow to use cache service which is aliasing.
Exemple : When I use this package in a projet with the sentry library. The sentry bundle aliasing de default service `cache.app`.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Unit tests
- [ ] Spec Tests
- [x] Integration tests / Manual Tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
