### PR TITLE
Fix issue where CONTEXT_VALUE_NOT_FOUND would never be triggered

### DIFF
--- a/src/Context/SymfonyUnleashContext.php
+++ b/src/Context/SymfonyUnleashContext.php
@@ -202,7 +202,7 @@ final class SymfonyUnleashContext implements Context
             ContextField::IP_ADDRESS => $this->getIpAddress(),
             ContextField::ENVIRONMENT => $this->getEnvironment(),
             ContextField::CURRENT_TIME => $this->getCurrentTime()->format(DateTimeInterface::ISO8601),
-            default => $this->hasCustomProperty($fieldName) ? $this->getCustomProperty($fieldName) : null,
+            default => $this->getCustomProperty($fieldName),
         };
     }
 

--- a/src/Context/SymfonyUnleashContext.php
+++ b/src/Context/SymfonyUnleashContext.php
@@ -202,8 +202,17 @@ final class SymfonyUnleashContext implements Context
             ContextField::IP_ADDRESS => $this->getIpAddress(),
             ContextField::ENVIRONMENT => $this->getEnvironment(),
             ContextField::CURRENT_TIME => $this->getCurrentTime()->format(DateTimeInterface::ISO8601),
-            default => $this->getCustomProperty($fieldName),
+            default => $this->findCustomProperty($fieldName),
         };
+    }
+
+    public function findCustomProperty(string $name): ?string
+    {
+        try {
+            return $this->getCustomProperty($name);
+        } catch (InvalidArgumentException) {
+            return null;
+        }
     }
 
     public function getEnvironment(): ?string


### PR DESCRIPTION
The default will check if the custom context exists, but as it's through the event, it will never exist.

# Description

Let the get custom property figure out if it exists or not.

Fixes # (issue)

That you can never use the event to set context

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
