### PR TITLE
Introduce #[IsNotEnabled] attribute to complement #[IsEnabled]

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ class MyService
 
 ## Controller attribute
 
-You can also check for feature flag using an `#[IsEnabled]` attribute on a controller. You can use it on the whole
-controller class as well as on a concrete method.
+You can also check for feature flag using `#[IsEnabled]` and `#[IsNotEnabled]` attributes on a controller. You can use
+it on the whole controller class as well as on a concrete method.
 
 ```php
 <?php
@@ -64,7 +64,6 @@ controller class as well as on a concrete method.
 use Unleash\Client\Bundle\Attribute\IsEnabled;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\HttpFoundation\Response;
 
 #[IsEnabled('my_awesome_feature')]
 final class MyController
@@ -88,12 +87,33 @@ In the example above the user on `/my-route` needs both `my_awesome_feature` and
 (because of one attribute on the class and another attribute on the method) while the `/other-route` needs only
 `my_awesome_feature` enabled (because of class attribute).
 
+```php
+<?php
+
+use Unleash\Client\Bundle\Attribute\IsNotEnabled;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+#[IsNotEnabled('kill_switch')]
+final class MyHeavyController
+{
+    #[Route('/my-route')]
+    public function myRoute(): Response
+    {
+        // todo
+    }
+}
+```
+
+In the second example, `/my-route` route is only enabled if `kill_switch` is **not** enabled.
+
 You can also notice that one of the attributes specifies a second optional parameter with status code. The supported
 status codes are:
 - `404` - `NotFoundHttpException`
 - `403` - `AccessDeniedHttpException`
 - `400` - `BadRequestHttpException`
-- `401` - `UnauthorizedHttpException` with message "Unauthorized". 
+- `401` - `UnauthorizedHttpException` with message "Unauthorized".
+- `503` - `ServiceUnavailableHttpException`
 
 The default status code is `404`. If you use an unsupported status code `InvalidValueException` will be thrown.
 

--- a/src/Attribute/ControllerAttribute.php
+++ b/src/Attribute/ControllerAttribute.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Unleash\Client\Bundle\Attribute;
+
+use JetBrains\PhpStorm\ExpectedValues;
+use Symfony\Component\HttpFoundation\Response;
+
+interface ControllerAttribute
+{
+    public function getFeatureName(): string;
+
+    #[ExpectedValues([
+        Response::HTTP_NOT_FOUND,
+        Response::HTTP_FORBIDDEN,
+        Response::HTTP_BAD_REQUEST,
+        Response::HTTP_UNAUTHORIZED,
+        Response::HTTP_SERVICE_UNAVAILABLE,
+    ])]
+    public function getErrorCode(): int;
+}

--- a/src/Attribute/IsNotEnabled.php
+++ b/src/Attribute/IsNotEnabled.php
@@ -7,7 +7,7 @@ use JetBrains\PhpStorm\ExpectedValues;
 use Symfony\Component\HttpFoundation\Response;
 
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
-final class IsEnabled implements ControllerAttribute
+final class IsNotEnabled implements ControllerAttribute
 {
     public function __construct(
         public string $featureName,


### PR DESCRIPTION
# Description

The `#[IsEnabled]` attribute is really helpful but can't help with negated flags, such as kill switches. The `#[IsNotEnabled]` attribute introduced in this PR aims to fill the need, by just reversing the throwing logic, but keep reusing the infrastructure already in place.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Unit tests
- [ ] Spec Tests
- [x] Integration tests / Manual Tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

NB: I couldn't find the tests in this repo, did I miss something ?