### PR TITLE
Fix: Support http_discovery factory

### DIFF
--- a/src/DependencyInjection/Compiler/HttpServicesResolverCompilerPass.php
+++ b/src/DependencyInjection/Compiler/HttpServicesResolverCompilerPass.php
@@ -38,6 +38,15 @@ final class HttpServicesResolverCompilerPass implements CompilerPassInterface
         }
 
         $requestFactoryServiceName = $configs['request_factory_service'];
+        if ($requestFactoryServiceName === null) {
+            if ($container->hasDefinition('nyholm.psr7.psr17_factory')) {
+                $requestFactoryServiceName = 'nyholm.psr7.psr17_factory';
+            } elseif ($container->hasDefinition('http_discovery.psr17_factory')) {
+                $requestFactoryServiceName = 'http_discovery.psr17_factory';
+            } else {
+                throw new InvalidConfigurationException('Cannot find any supported default request factory service, tried nyholm and http_discovery');
+            }
+        }
         $definition = $container->getDefinition($requestFactoryServiceName);
         $class = $definition->getClass();
         assert(is_string($class));

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -65,7 +65,7 @@ final class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('request_factory_service')
                     ->info('The request factory service, must implement the ' . RequestFactoryInterface::class . ' interface')
-                    ->defaultValue('nyholm.psr7.psr17_factory')
+                    ->defaultNull()
                 ->end()
                 ->scalarNode('cache_service')
                     ->info('The cache service, must implement the ' . CacheInterface::class . ' or ' . CacheItemPoolInterface::class . ' interface')

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -64,7 +64,7 @@ final class Configuration implements ConfigurationInterface
                     ->defaultValue('psr18.http_client')
                 ->end()
                 ->scalarNode('request_factory_service')
-                    ->info('The request factory service, must implement the ' . RequestFactoryInterface::class . ' interface')
+                    ->info('The request factory service, must implement the ' . RequestFactoryInterface::class . ' interface. Providing null means autodetect between supported default services.')
                     ->defaultNull()
                 ->end()
                 ->scalarNode('cache_service')


### PR DESCRIPTION
# Description

It seems the default for Symfony has changed and the previous configuration is no longer supported. This supports both of them fro compatibility with older versions.

Might be related to #32 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Integration tests / Manual Tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
