### PR TITLE
Fix: Always provide bootstrap provider

### DIFF
--- a/src/DependencyInjection/Compiler/BootstrapResolver.php
+++ b/src/DependencyInjection/Compiler/BootstrapResolver.php
@@ -6,6 +6,7 @@ use LogicException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Unleash\Client\Bootstrap\EmptyBootstrapProvider;
 use Unleash\Client\Bootstrap\FileBootstrapProvider;
 
 /**
@@ -37,6 +38,8 @@ final readonly class BootstrapResolver implements CompilerPassInterface
     {
         $serviceIds = array_keys($container->findTaggedServiceIds(self::TAG));
         if (!count($serviceIds)) {
+            $this->registerEmptyService($container);
+
             return;
         }
 
@@ -60,5 +63,11 @@ final readonly class BootstrapResolver implements CompilerPassInterface
     private function registerServiceService(string $serviceId, ContainerBuilder $container): void
     {
         $container->setAlias(self::INTERNAL_SERVICE_NAME, $serviceId);
+    }
+
+    private function registerEmptyService(ContainerBuilder $container): void
+    {
+        $definition = new Definition(EmptyBootstrapProvider::class);
+        $container->setDefinition(self::INTERNAL_SERVICE_NAME, $definition);
     }
 }

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -94,7 +94,7 @@ services:
       $headers: '%unleash.client.internal.custom_headers%'
       $autoRegistrationEnabled: '%unleash.client.internal.auto_registration%'
       $contextProvider: '@unleash.client.internal.context_provider'
-      $bootstrapProvider: '@?unleash.client.internal.bootstrap_service'
+      $bootstrapProvider: '@unleash.client.internal.bootstrap_service'
       $fetchingEnabled: '%unleash.client.internal.fetching_enabled%'
       $eventDispatcher: '@event_dispatcher'
       $staleTtl: '%unleash.client.internal.stale_ttl%'


### PR DESCRIPTION
# Description

Bootstrap provider is now a mandatory parameter in v2 of Unleash SDK, thus it needs to always be provided.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Manual Tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
