### PR TITLE
Fix: Frozen bag warning when loading services after container is dumped

### DIFF
--- a/src/DependencyInjection/UnleashClientExtension.php
+++ b/src/DependencyInjection/UnleashClientExtension.php
@@ -19,6 +19,8 @@ use Unleash\Client\Strategy\StrategyHandler;
  */
 final class UnleashClientExtension extends Extension
 {
+    private bool $servicesYamlLoaded = false;
+
     /**
      * @param array<string,mixed> $configs
      *
@@ -32,6 +34,7 @@ final class UnleashClientExtension extends Extension
         if (interface_exists(ExtensionInterface::class)) {
             $loader->load('twig.yaml');
         }
+        $this->servicesYamlLoaded = true;
 
         $configs = $this->processConfiguration($this->getConfiguration([], $container), $configs);
         $container->setParameter('unleash.client.internal.service_configs', [
@@ -82,7 +85,10 @@ final class UnleashClientExtension extends Extension
     public function getConfiguration(array $config, ContainerBuilder $container): Configuration
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
-        $loader->load('services.yaml');
+        if (!$this->servicesYamlLoaded) {
+            $loader->load('services.yaml');
+            $this->servicesYamlLoaded = true;
+        }
 
         $handlerNames = [];
         foreach ($this->getDefaultStrategyHandlers($container) as $defaultStrategyHandler) {


### PR DESCRIPTION
# Description

Services were previously loaded every time a configuration was generated (including after the container was finished and cannot be modified), now it only loads services once.

Fixes #49 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manual Tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
