### PR TITLE
Feat: Add environment variable support for DSN

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "symfony/http-client": "^5.0 | ^6.0 | ^7.0",
         "symfony/cache": "^5.0 | ^6.0 | ^7.0",
         "nyholm/psr7": "^1.0",
-        "unleash/client": "^1.6 | ^2.0",
+        "unleash/client": "^2.4",
         "php": "^8.2"
     },
     "autoload": {

--- a/src/DependencyInjection/Dsn/LateBoundDsnParameter.php
+++ b/src/DependencyInjection/Dsn/LateBoundDsnParameter.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Unleash\Client\Bundle\DependencyInjection\Dsn;
+
+use Stringable;
+
+final readonly class LateBoundDsnParameter implements Stringable
+{
+    public function __construct(
+        private string $envName,
+        private string $parameter,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        $dsn = getenv($this->envName) ?: $_ENV[$this->envName] ?? null;
+        if ($dsn === null) {
+            return '';
+        }
+
+        $query = parse_url($dsn, PHP_URL_QUERY);
+        assert(is_string($query));
+        $instanceUrl = str_replace("?{$query}", '', $dsn);
+        if (str_contains($instanceUrl, '%3F')) {
+            $instanceUrl = urldecode($instanceUrl);
+        }
+        if ($this->parameter === 'url') {
+            return $instanceUrl;
+        }
+        parse_str($query, $queryParts);
+
+        $result = $queryParts[$this->parameter] ?? '';
+        assert(is_string($result));
+
+        return $result;
+    }
+}

--- a/src/DependencyInjection/Dsn/StaticStringableParameter.php
+++ b/src/DependencyInjection/Dsn/StaticStringableParameter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Unleash\Client\Bundle\DependencyInjection\Dsn;
+
+use Stringable;
+
+final readonly class StaticStringableParameter implements Stringable
+{
+    public function __construct(
+        private string $value,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -84,9 +84,9 @@ services:
   unleash.client.configuration:
     class: Unleash\Client\Configuration\UnleashConfiguration
     arguments:
-      $url: '%unleash.client.internal.app_url%'
-      $appName: '%unleash.client.internal.app_name%'
-      $instanceId: '%unleash.client.internal.instance_id%'
+      $url: '@unleash.client.internal.app_url'
+      $appName: '@unleash.client.internal.app_name'
+      $instanceId: '@unleash.client.internal.instance_id'
       $cache: '@unleash.client.internal.cache'
       $ttl: '%unleash.client.internal.cache_ttl%'
       $metricsInterval: '%unleash.client.internal.metrics_send_interval%'


### PR DESCRIPTION
# Description

This uses the recently introduced Stringable support for basic parameters to allow runtime bound values in the container, which is the expected way to support env binding in Symfony apps (as opposed to just binding the parameter from the env variable at the time the container was built).

A proxy class for static values has been created as well so that we don't have to do another unnecessary round of if/else and just provide a service with the same name as opposed to distinguishing between the service (`Stringable` instances) and parameters (static `string` values), especially because they have different syntax in the `services.yaml` config (`%parameter_name%` vs `@service_name`).

Fixes #66 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Manual Tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
