### PR TITLE
Chore: Update code to not trigger PHPStan errors

### DIFF
--- a/src/Twig/FeatureTagTokenParser.php
+++ b/src/Twig/FeatureTagTokenParser.php
@@ -22,6 +22,8 @@ final class FeatureTagTokenParser extends AbstractTokenParser
         $stream->expect(Token::NAME_TYPE, 'endfeature');
         $stream->expect(Token::BLOCK_END_TYPE);
 
+        assert(is_string($featureName));
+
         return new FeatureTagNode($featureName, $body, $token->getLine(), $this->getTag(), $this->extensionClass);
     }
 


### PR DESCRIPTION
# Description

The error occurred in some newer versions of PHPStan and Twig is not typed sufficiently, so we have to do an assert. The error occurred in #77.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
