### PR TITLE
Do not call Reflection*::setAccessible()

### DIFF
--- a/src/Context/SymfonyUnleashContext.php
+++ b/src/Context/SymfonyUnleashContext.php
@@ -62,7 +62,6 @@ final class SymfonyUnleashContext implements Context
             }
             $reflection = new ReflectionObject($user);
             $idProperty = $reflection->getProperty($this->userIdField);
-            $idProperty->setAccessible(true);
 
             $value = $idProperty->getValue($user);
             if (!is_scalar($value) && !$value instanceof Stringable) {


### PR DESCRIPTION
# Description

> As of PHP 8.1.0, calling this method has no effect; all methods are invokable by default.

(https://www.php.net/manual/en/reflectionmethod.setaccessible.php and https://www.php.net/manual/en/reflectionproperty.setaccessible.php).

There're even plans to deprecate the method in PHP 8.5: https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations

## Type of change

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
